### PR TITLE
Use the new support_forum method to find the IRC channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: perl
+perl:
+  - "5.14"
+  - "5.20"
+  - "5.22"
+  - "5.24"
+  - "5.26"
+before_install:
+  - export DIST_INKT_PROFILE="Dist::Inkt::Profile::TOBYINK"
+  - git clone git://github.com/tobyink/perl-travis-helper
+  - source perl-travis-helper/init
+  - build-perl
+  - perl -V
+  - build-dist
+  - cd $BUILD_DIR
+install:
+  - cpan-install --toolchain
+  - cpan-install --deps
+  - cpan-install --coverage
+before_script:
+  - coverage-setup
+script:
+  - prove -l $(test-dirs)
+after_success:
+  - coverage-report
+
+
+notifications:
+  irc: "irc://irc.perl.org/#perlrdf"
+

--- a/README.pod
+++ b/README.pod
@@ -1,0 +1,1 @@
+lib/Dist/Inkt/DOAP.pm

--- a/lib/Dist/Inkt/DOAP.pm
+++ b/lib/Dist/Inkt/DOAP.pm
@@ -61,10 +61,11 @@ L<Dist::Inkt>.
 =head1 AUTHOR
 
 Toby Inkster E<lt>tobyink@cpan.orgE<gt>.
+Kjetil Kjernsmo E<lt>kjetilk@cpan.orgE<gt>.
 
 =head1 COPYRIGHT AND LICENCE
 
-This software is copyright (c) 2014 by Toby Inkster.
+This software is copyright (c) 2014 by Toby Inkster, 2017 by Kjetil Kjernsmo
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/lib/Dist/Inkt/DOAP.pm
+++ b/lib/Dist/Inkt/DOAP.pm
@@ -52,7 +52,7 @@ Index. >>
 =head1 BUGS
 
 Please report any bugs to
-L<http://rt.cpan.org/Dist/Display.html?Queue=Dist-Inkt-DOAP>.
+L<https://github.com/kjetilk/p5-dist-inkt-doap/issues>
 
 =head1 SEE ALSO
 

--- a/lib/Dist/Inkt/DOAP.pm
+++ b/lib/Dist/Inkt/DOAP.pm
@@ -5,7 +5,7 @@ use warnings;
 package Dist::Inkt::DOAP;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.022';
+our $VERSION   = '0.023_01';
 
 1;
 

--- a/lib/Dist/Inkt/DOAP.pm
+++ b/lib/Dist/Inkt/DOAP.pm
@@ -5,7 +5,7 @@ use warnings;
 package Dist::Inkt::DOAP;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_01';
+our $VERSION   = '0.023_02';
 
 1;
 

--- a/lib/Dist/Inkt/DOAP.pm
+++ b/lib/Dist/Inkt/DOAP.pm
@@ -5,7 +5,7 @@ use warnings;
 package Dist::Inkt::DOAP;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_02';
+our $VERSION   = '0.100';
 
 1;
 

--- a/lib/Dist/Inkt/Role/DetermineRightsFromRdf.pm
+++ b/lib/Dist/Inkt/Role/DetermineRightsFromRdf.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::DetermineRightsFromRdf;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_01';
+our $VERSION   = '0.023_02';
 
 use Moose::Role;
 use RDF::Trine qw( iri literal statement variable );

--- a/lib/Dist/Inkt/Role/DetermineRightsFromRdf.pm
+++ b/lib/Dist/Inkt/Role/DetermineRightsFromRdf.pm
@@ -5,7 +5,7 @@ our $VERSION   = '0.022';
 
 use Moose::Role;
 use RDF::Trine qw( iri literal statement variable );
-use List::MoreUtils qw( uniq );
+use List::Util qw( uniq );
 use Path::Tiny qw( path );
 use Path::Iterator::Rule;
 use Software::License;

--- a/lib/Dist/Inkt/Role/DetermineRightsFromRdf.pm
+++ b/lib/Dist/Inkt/Role/DetermineRightsFromRdf.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::DetermineRightsFromRdf;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.022';
+our $VERSION   = '0.023_01';
 
 use Moose::Role;
 use RDF::Trine qw( iri literal statement variable );

--- a/lib/Dist/Inkt/Role/DetermineRightsFromRdf.pm
+++ b/lib/Dist/Inkt/Role/DetermineRightsFromRdf.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::DetermineRightsFromRdf;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_02';
+our $VERSION   = '0.100';
 
 use Moose::Role;
 use RDF::Trine qw( iri literal statement variable );

--- a/lib/Dist/Inkt/Role/ProcessDOAP.pm
+++ b/lib/Dist/Inkt/Role/ProcessDOAP.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::ProcessDOAP;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_01';
+our $VERSION   = '0.023_02';
 
 use Moose::Role;
 use List::Util 'uniq';

--- a/lib/Dist/Inkt/Role/ProcessDOAP.pm
+++ b/lib/Dist/Inkt/Role/ProcessDOAP.pm
@@ -159,12 +159,14 @@ sub cpanmeta_resources
 		grep defined,
 		$self->model->objects(RDF::Trine::iri($self->project_uri), $CPAN->x_IRC);
 
-	foreach my $forum (@{ $self->doap_project->support_forum }) {
-		my $forumuri = URI->new($forum->uri);
-		if ($forumuri->scheme =~ m/^ircs?$/) {
+	if (defined($self->doap_project->support_forum)) {
+	  foreach my $forum (@{ $self->doap_project->support_forum }) {
+		 my $forumuri = URI->new($forum->uri);
+		 if ($forumuri->scheme =~ m/^ircs?$/) {
 			$resources{x_IRC} = $forumuri->as_string;
 			last;
-		}
+		 }
+	  }
 	}
 
 	delete $resources{$_} for grep !defined $resources{$_}, keys %resources;

--- a/lib/Dist/Inkt/Role/ProcessDOAP.pm
+++ b/lib/Dist/Inkt/Role/ProcessDOAP.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::ProcessDOAP;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_02';
+our $VERSION   = '0.100';
 
 use Moose::Role;
 use List::Util 'uniq';

--- a/lib/Dist/Inkt/Role/ProcessDOAP.pm
+++ b/lib/Dist/Inkt/Role/ProcessDOAP.pm
@@ -6,6 +6,7 @@ our $VERSION   = '0.022';
 use Moose::Role;
 use List::MoreUtils 'uniq';
 use namespace::autoclean;
+use URI;
 
 with 'Dist::Inkt::Role::RDFModel';
 
@@ -157,7 +158,15 @@ sub cpanmeta_resources
 		map  { $_->uri }
 		grep defined,
 		$self->model->objects(RDF::Trine::iri($self->project_uri), $CPAN->x_IRC);
-	
+
+	foreach my $forum (@{ $self->doap_project->support_forum }) {
+		my $forumuri = URI->new($forum->uri);
+		if ($forumuri->scheme =~ m/^ircs?$/) {
+			$resources{x_IRC} = $forumuri->as_string;
+			last;
+		}
+	}
+
 	delete $resources{$_} for grep !defined $resources{$_}, keys %resources;
 	
 	return \%resources;

--- a/lib/Dist/Inkt/Role/ProcessDOAP.pm
+++ b/lib/Dist/Inkt/Role/ProcessDOAP.pm
@@ -4,7 +4,7 @@ our $AUTHORITY = 'cpan:TOBYINK';
 our $VERSION   = '0.022';
 
 use Moose::Role;
-use List::MoreUtils 'uniq';
+use List::Util 'uniq';
 use namespace::autoclean;
 use URI;
 

--- a/lib/Dist/Inkt/Role/ProcessDOAP.pm
+++ b/lib/Dist/Inkt/Role/ProcessDOAP.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::ProcessDOAP;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.022';
+our $VERSION   = '0.023_01';
 
 use Moose::Role;
 use List::Util 'uniq';

--- a/lib/Dist/Inkt/Role/ProcessDOAPDeps.pm
+++ b/lib/Dist/Inkt/Role/ProcessDOAPDeps.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::ProcessDOAPDeps;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_02';
+our $VERSION   = '0.100';
 
 use Moose::Role;
 use namespace::autoclean;

--- a/lib/Dist/Inkt/Role/ProcessDOAPDeps.pm
+++ b/lib/Dist/Inkt/Role/ProcessDOAPDeps.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::ProcessDOAPDeps;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_01';
+our $VERSION   = '0.023_02';
 
 use Moose::Role;
 use namespace::autoclean;

--- a/lib/Dist/Inkt/Role/ProcessDOAPDeps.pm
+++ b/lib/Dist/Inkt/Role/ProcessDOAPDeps.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::ProcessDOAPDeps;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.022';
+our $VERSION   = '0.023_01';
 
 use Moose::Role;
 use namespace::autoclean;

--- a/lib/Dist/Inkt/Role/RDFModel.pm
+++ b/lib/Dist/Inkt/Role/RDFModel.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::RDFModel;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.022';
+our $VERSION   = '0.023_01';
 
 use Moose::Role;
 use Types::Standard -types;

--- a/lib/Dist/Inkt/Role/RDFModel.pm
+++ b/lib/Dist/Inkt/Role/RDFModel.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::RDFModel;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_02';
+our $VERSION   = '0.100';
 
 use Moose::Role;
 use Types::Standard -types;

--- a/lib/Dist/Inkt/Role/RDFModel.pm
+++ b/lib/Dist/Inkt/Role/RDFModel.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::RDFModel;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_01';
+our $VERSION   = '0.023_02';
 
 use Moose::Role;
 use Types::Standard -types;

--- a/lib/Dist/Inkt/Role/ReadMetaDir.pm
+++ b/lib/Dist/Inkt/Role/ReadMetaDir.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::ReadMetaDir;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_01';
+our $VERSION   = '0.023_02';
 
 use Moose::Role;
 use RDF::TrineX::Functions 'parse';

--- a/lib/Dist/Inkt/Role/ReadMetaDir.pm
+++ b/lib/Dist/Inkt/Role/ReadMetaDir.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::ReadMetaDir;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_02';
+our $VERSION   = '0.100';
 
 use Moose::Role;
 use RDF::TrineX::Functions 'parse';

--- a/lib/Dist/Inkt/Role/ReadMetaDir.pm
+++ b/lib/Dist/Inkt/Role/ReadMetaDir.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::ReadMetaDir;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.022';
+our $VERSION   = '0.023_01';
 
 use Moose::Role;
 use RDF::TrineX::Functions 'parse';

--- a/lib/Dist/Inkt/Role/Test/Changes.pm
+++ b/lib/Dist/Inkt/Role/Test/Changes.pm
@@ -5,7 +5,7 @@ use warnings;
 package Dist::Inkt::Role::Test::Changes;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_01';
+our $VERSION   = '0.023_02';
 
 use Moose::Role;
 with qw(

--- a/lib/Dist/Inkt/Role/Test/Changes.pm
+++ b/lib/Dist/Inkt/Role/Test/Changes.pm
@@ -5,7 +5,7 @@ use warnings;
 package Dist::Inkt::Role::Test::Changes;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_02';
+our $VERSION   = '0.100';
 
 use Moose::Role;
 with qw(

--- a/lib/Dist/Inkt/Role/Test/Changes.pm
+++ b/lib/Dist/Inkt/Role/Test/Changes.pm
@@ -5,7 +5,7 @@ use warnings;
 package Dist::Inkt::Role::Test::Changes;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.022';
+our $VERSION   = '0.023_01';
 
 use Moose::Role;
 with qw(

--- a/lib/Dist/Inkt/Role/WriteCOPYRIGHT.pm
+++ b/lib/Dist/Inkt/Role/WriteCOPYRIGHT.pm
@@ -4,7 +4,7 @@ our $AUTHORITY = 'cpan:TOBYINK';
 our $VERSION   = '0.022';
 
 use Moose::Role;
-use List::MoreUtils qw( uniq );
+use List::Util qw( uniq );
 use Path::Tiny qw( path );
 use Path::Iterator::Rule;
 use Software::License;

--- a/lib/Dist/Inkt/Role/WriteCOPYRIGHT.pm
+++ b/lib/Dist/Inkt/Role/WriteCOPYRIGHT.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::WriteCOPYRIGHT;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_02';
+our $VERSION   = '0.100';
 
 use Moose::Role;
 use List::Util qw( uniq );

--- a/lib/Dist/Inkt/Role/WriteCOPYRIGHT.pm
+++ b/lib/Dist/Inkt/Role/WriteCOPYRIGHT.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::WriteCOPYRIGHT;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.022';
+our $VERSION   = '0.023_01';
 
 use Moose::Role;
 use List::Util qw( uniq );

--- a/lib/Dist/Inkt/Role/WriteCOPYRIGHT.pm
+++ b/lib/Dist/Inkt/Role/WriteCOPYRIGHT.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::WriteCOPYRIGHT;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_01';
+our $VERSION   = '0.023_02';
 
 use Moose::Role;
 use List::Util qw( uniq );

--- a/lib/Dist/Inkt/Role/WriteCREDITS.pm
+++ b/lib/Dist/Inkt/Role/WriteCREDITS.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::WriteCREDITS;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_02';
+our $VERSION   = '0.100';
 
 use Moose::Role;
 use namespace::autoclean;

--- a/lib/Dist/Inkt/Role/WriteCREDITS.pm
+++ b/lib/Dist/Inkt/Role/WriteCREDITS.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::WriteCREDITS;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_01';
+our $VERSION   = '0.023_02';
 
 use Moose::Role;
 use namespace::autoclean;

--- a/lib/Dist/Inkt/Role/WriteCREDITS.pm
+++ b/lib/Dist/Inkt/Role/WriteCREDITS.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::WriteCREDITS;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.022';
+our $VERSION   = '0.023_01';
 
 use Moose::Role;
 use namespace::autoclean;

--- a/lib/Dist/Inkt/Role/WriteChanges.pm
+++ b/lib/Dist/Inkt/Role/WriteChanges.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::WriteChanges;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_02';
+our $VERSION   = '0.100';
 
 use Moose::Role;
 use namespace::autoclean;

--- a/lib/Dist/Inkt/Role/WriteChanges.pm
+++ b/lib/Dist/Inkt/Role/WriteChanges.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::WriteChanges;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.022';
+our $VERSION   = '0.023_01';
 
 use Moose::Role;
 use namespace::autoclean;

--- a/lib/Dist/Inkt/Role/WriteChanges.pm
+++ b/lib/Dist/Inkt/Role/WriteChanges.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::WriteChanges;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_01';
+our $VERSION   = '0.023_02';
 
 use Moose::Role;
 use namespace::autoclean;

--- a/lib/Dist/Inkt/Role/WriteDOAP.pm
+++ b/lib/Dist/Inkt/Role/WriteDOAP.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::WriteDOAP;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_02';
+our $VERSION   = '0.100';
 
 use Moose::Role;
 use RDF::TrineX::Functions 'serialize';

--- a/lib/Dist/Inkt/Role/WriteDOAP.pm
+++ b/lib/Dist/Inkt/Role/WriteDOAP.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::WriteDOAP;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.022';
+our $VERSION   = '0.023_01';
 
 use Moose::Role;
 use RDF::TrineX::Functions 'serialize';

--- a/lib/Dist/Inkt/Role/WriteDOAP.pm
+++ b/lib/Dist/Inkt/Role/WriteDOAP.pm
@@ -1,7 +1,7 @@
 package Dist::Inkt::Role::WriteDOAP;
 
 our $AUTHORITY = 'cpan:TOBYINK';
-our $VERSION   = '0.023_01';
+our $VERSION   = '0.023_02';
 
 use Moose::Role;
 use RDF::TrineX::Functions 'serialize';

--- a/meta/changes.pret
+++ b/meta/changes.pret
@@ -43,7 +43,7 @@
 		item "ETHER wants me to use a version range string in x_breaks."^^Change;
 	].
 
-`Dist-Inkt-DOAP 0.023_01 cpan:KJETILK`
+`Dist-Inkt-DOAP 0.023_02 cpan:KJETILK`
 	issued  2017-12-21;
 	changeset [
 	  item "Replace List::MoreUtils with List::Util."^^Change;

--- a/meta/changes.pret
+++ b/meta/changes.pret
@@ -42,3 +42,11 @@
 	changeset [
 		item "ETHER wants me to use a version range string in x_breaks."^^Change;
 	].
+
+`Dist-Inkt-DOAP 0.023_01 cpan:KJETILK`
+	issued  2017-12-21;
+	changeset [
+	  item "Replace List::MoreUtils with List::Util."^^Change;
+ 	  item "Use RDF::DOAP::Project method to find IRC channel."^^Addition;
+	  item "Some minor changes."^^Change;
+	].

--- a/meta/changes.pret
+++ b/meta/changes.pret
@@ -43,8 +43,8 @@
 		item "ETHER wants me to use a version range string in x_breaks."^^Change;
 	].
 
-`Dist-Inkt-DOAP 0.023_02 cpan:KJETILK`
-	issued  2017-12-21;
+`Dist-Inkt-DOAP 0.100 cpan:KJETILK`
+	issued  2017-12-22;
 	changeset [
 	  item "Replace List::MoreUtils with List::Util."^^Change;
  	  item "Use RDF::DOAP::Project method to find IRC channel."^^Addition;

--- a/meta/doap.pret
+++ b/meta/doap.pret
@@ -12,7 +12,7 @@
     :download-page        <https://metacpan.org/release/Dist-Inkt-DOAP>;
     :bug-database         <https://github.com/kjetilk/p5-dist-inkt-doap/issues>;
     :repository           [ a :GitRepository;
-        :browse <https://github.com/kjetilk/p5-dist-inkt-doap>
+        :browse <https://github.com/kjetilk/p5-dist-inkt-doap> ;
         prov:has_provenance <http://git2prov.org/git2prov?giturl=https%3A%2F%2Fgithub.com%2Fkjetilk%2Fp5-dist-inkt-doap&serialization=PROV-O#>
         ];
     :support-forum        <irc://irc.perl.org/#perlrdf> ;

--- a/meta/doap.pret
+++ b/meta/doap.pret
@@ -1,20 +1,27 @@
 # This file contains general metadata about the project.
 
 @prefix : <http://usefulinc.com/ns/doap#>.
-@prefix cpant: <http://purl.org/NET/cpan-uri/terms#>.
+@prefix prov: <http://www.w3.org/ns/prov#>.
+@prefix result: <http://git2prov.org/git2prov?giturl=https%3A%2F%2Fgithub.com%2Fkjetilk%2Fp5-dist-inkt-doap&serialization=PROV-O#> .
+
 
 `Dist-Inkt-DOAP`
-	:programming-language "Perl" ;
-	:shortdesc            "various DOAP-related roles for Dist::Inkt";
-	:homepage             <https://metacpan.org/release/Dist-Inkt-DOAP>;
-	:download-page        <https://metacpan.org/release/Dist-Inkt-DOAP>;
-	:bug-database         <http://rt.cpan.org/Dist/Display.html?Queue=Dist-Inkt-DOAP>;
-	:repository           [ a :GitRepository; :browse <https://github.com/tobyink/p5-dist-inkt-doap> ];
-	cpant:x_IRC           <irc://irc.perl.org/#perlrdf>;
-	:created              2014-05-26;
-	:license              <http://dev.perl.org/licenses/>;
-	:maintainer           cpan:TOBYINK;
-	:developer            cpan:TOBYINK.
+    :programming-language "Perl" ;
+    :shortdesc            "various DOAP-related roles for Dist::Inkt";
+    :homepage             <https://metacpan.org/release/Dist-Inkt-DOAP>;
+    :download-page        <https://metacpan.org/release/Dist-Inkt-DOAP>;
+    :bug-database         <https://github.com/kjetilk/p5-dist-inkt-doap/issues>;
+    :repository           [ a :GitRepository;
+        :browse <https://github.com/kjetilk/p5-dist-inkt-doap>
+        prov:has_provenance <http://git2prov.org/git2prov?giturl=https%3A%2F%2Fgithub.com%2Fkjetilk%2Fp5-dist-inkt-doap&serialization=PROV-O#>
+        ];
+    :support-forum        <irc://irc.perl.org/#perlrdf> ;
+    :created              2014-05-26;
+    :license              <http://dev.perl.org/licenses/>;
+    :category             <http://dbpedia.org/resource/Category:Semantic_Web> ,
+                          <http://dbpedia.org/resource/Category:Package_management_systems> ;
+    :maintainer           cpan:TOBYINK, cpan:KJETILK ;
+    :developer            cpan:TOBYINK.
 
 <http://dev.perl.org/licenses/>
 	dc:title  "the same terms as the perl 5 programming language system itself".

--- a/meta/makefile.pret
+++ b/meta/makefile.pret
@@ -16,5 +16,13 @@
     :runtime-requirement    [ :on "RDF::TrineX::Parser::Pretdsl 0.205"^^:CpanId ];
     :runtime-requirement    [ :on "RDF::TrineX::Serializer::MockTurtleSoup 0"^^:CpanId ];
     
+    :runtime-requirement    [ :on "Path::Iterator::Rule 0"^^:CpanId ];
+    :runtime-requirement    [ :on "Path::Tiny 0"^^:CpanId ];
+    :runtime-requirement    [ :on "Software::License 0"^^:CpanId ];
+    :runtime-requirement    [ :on "Software::LicenseUtils 0"^^:CpanId ];
+    :runtime-requirement    [ :on "Types::Standard 0"^^:CpanId ];
+    :runtime-requirement    [ :on "URI 0"^^:CpanId ];
+    :runtime-requirement    [ :on "namespace::autoclean 0"^^:CpanId ];
+
     .
 

--- a/meta/makefile.pret
+++ b/meta/makefile.pret
@@ -8,7 +8,8 @@
 	:runtime-requirement    [ :on "Moose 2.0800"^^:CpanId ];
 	:runtime-requirement    [ :on "Dist::Inkt 0.017"^^:CpanId ];
 	:runtime-requirement    [ :on "Dist::Inkt::Role::Test"^^:CpanId ];
-	:runtime-requirement    [ :on "MooX::Struct 0"^^:CpanId ];
+        :runtime-requirement    [ :on "MooX::Struct 0"^^:CpanId ];
+    	:runtime-requirement    [ :on "List::Util 1.45"^^:CpanId ];
 	:runtime-requirement    [ :on "RDF::DOAP::Project 0.007"^^:CpanId ];
 	:runtime-requirement    [ :on "RDF::Trine 1.000"^^:CpanId ];
 	:runtime-requirement    [ :on "RDF::TrineX::Functions 0"^^:CpanId ];

--- a/meta/makefile.pret
+++ b/meta/makefile.pret
@@ -3,17 +3,18 @@
 @prefix : <http://ontologi.es/doap-deps#>.
 
 `Dist-Inkt-DOAP`
-	:test-requirement       [ :on "Test::More 0.96"^^:CpanId ];
-	:runtime-requirement    [ :on "perl 5.010001"^^:CpanId ];
-	:runtime-requirement    [ :on "Moose 2.0800"^^:CpanId ];
-	:runtime-requirement    [ :on "Dist::Inkt 0.017"^^:CpanId ];
-	:runtime-requirement    [ :on "Dist::Inkt::Role::Test"^^:CpanId ];
-        :runtime-requirement    [ :on "MooX::Struct 0"^^:CpanId ];
-    	:runtime-requirement    [ :on "List::Util 1.45"^^:CpanId ];
-	:runtime-requirement    [ :on "RDF::DOAP::Project 0.007"^^:CpanId ];
-	:runtime-requirement    [ :on "RDF::Trine 1.000"^^:CpanId ];
-	:runtime-requirement    [ :on "RDF::TrineX::Functions 0"^^:CpanId ];
-	:runtime-requirement    [ :on "RDF::TrineX::Parser::Pretdsl 0.205"^^:CpanId ];
-	:runtime-requirement    [ :on "RDF::TrineX::Serializer::MockTurtleSoup 0"^^:CpanId ];
-	.
+    :test-requirement       [ :on "Test::More 0.96"^^:CpanId ];
+    :runtime-requirement    [ :on "perl 5.010001"^^:CpanId ];
+    :runtime-requirement    [ :on "Moose 2.0800"^^:CpanId ];
+    :runtime-requirement    [ :on "Dist::Inkt 0.017"^^:CpanId ];
+    :runtime-requirement    [ :on "Dist::Inkt::Role::Test"^^:CpanId ];
+    :runtime-requirement    [ :on "MooX::Struct 0"^^:CpanId ];
+    :runtime-requirement    [ :on "List::Util 1.45"^^:CpanId ];
+    :runtime-requirement    [ :on "RDF::DOAP::Project 0.007"^^:CpanId ];
+    :runtime-requirement    [ :on "RDF::Trine 1.000"^^:CpanId ];
+    :runtime-requirement    [ :on "RDF::TrineX::Functions 0"^^:CpanId ];
+    :runtime-requirement    [ :on "RDF::TrineX::Parser::Pretdsl 0.205"^^:CpanId ];
+    :runtime-requirement    [ :on "RDF::TrineX::Serializer::MockTurtleSoup 0"^^:CpanId ];
+    
+    .
 

--- a/meta/people.pret
+++ b/meta/people.pret
@@ -1,9 +1,18 @@
 # This file contains data about the project developers.
 
 @prefix : <http://xmlns.com/foaf/0.1/>.
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix result: <http://git2prov.org/git2prov?giturl=https%3A%2F%2Fgithub.com%2Fkjetilk%2Fp5-dist-inkt-doap&serialization=PROV-O#> .
+
 
 cpan:TOBYINK
-	:name  "Toby Inkster";
-	:page  <https://metacpan.org/author/TOBYINK>;
-	:mbox  <mailto:tobyink@cpan.org>.
+    :name  "Toby Inkster";
+    owl:sameAs  result:user-Toby-Inkster ;
+    :page  <https://metacpan.org/author/TOBYINK>;
+    :mbox  <mailto:tobyink@cpan.org>.
 
+cpan:KJETILK
+    a           foaf:Person ;
+    owl:sameAs  <http://www.kjetil.kjernsmo.net/foaf#me> , result:user-Kjetil-Kjernsmo ;
+    :name   "Kjetil Kjernsmo" ;
+    :mbox   <mailto:kjetilk@cpan.org> .


### PR DESCRIPTION
Now that there is a way to do this in DOAP, it makes sense to use it, so this overrides the old one if it is present.